### PR TITLE
fix: keyboard popping route issue

### DIFF
--- a/lib/likeminds_chat_ss_fl.dart
+++ b/lib/likeminds_chat_ss_fl.dart
@@ -89,12 +89,7 @@ class LMChat extends StatelessWidget {
                 )
               ],
               child: MaterialApp.router(
-                routerConfig: router
-                  ..go(
-                    _defaultChatroom != null
-                        ? '/chatroom/$_defaultChatroom/'
-                        : '/',
-                  ),
+                routerConfig: router,
                 debugShowCheckedModeBanner: !isDebug,
                 theme: ThemeData(
                   colorScheme: ColorScheme.fromSeed(


### PR DESCRIPTION
This might break the `defaultChatroom` functionality. But I'm sure there would be another way to do that. I haven't used go router before so I am not sure. But yeah, removing those lines fixes the bug.

![fix](https://github.com/LikeMindsCommunity/LikeMinds-Flutter-Chat-SS/assets/57872180/47371bc3-ead4-45e4-b90a-14f297e4b5f5)

PS:
The reason I ask to remove useless files from git.
Introduces unnecessary changes
![image](https://github.com/LikeMindsCommunity/LikeMinds-Flutter-Chat-SS/assets/57872180/f1ccbb4f-04b7-43ee-989d-7dc0fa81d9c1)
